### PR TITLE
Production-izing ESprint Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+build/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rm -rf build && mkdir build && babel src --out-dir build",
     "prepublish": "npm run build",
-    "start": "babel --watch src --out-dir build"
+    "start": "babel --watch src --out-dir build",
+    "deps": "node ./scripts/installDependencies.js"
   },
   "repository": {
     "type": "git",
@@ -23,6 +24,7 @@
     "dnode": "^1.2.2",
     "fb-watchman": "^2.0.0",
     "glob": "^7.1.1",
+    "sane": "^1.6.0",
     "worker-farm": "^1.3.1",
     "yargs": "^6.5.0"
   },

--- a/scripts/installDependencies.js
+++ b/scripts/installDependencies.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+const execSync = require('child_process').execSync;
+const readFileSync = require('fs').readFileSync;
+const path = require('path');
+
+const packageJson = JSON.parse(readFileSync(path.join(process.argv[2], 'package.json')));
+
+if (!packageJson) {
+  console.log('No package.json found at the path specified. Exiting...');
+  process.exit(0);
+}
+
+let packages = [];
+let command = 'npm i ';
+
+const devDeps = packageJson['devDependencies'];
+
+for (const key in devDeps) {
+  if (key.indexOf('eslint') !== -1) {
+    command += `${key}@` + devDeps[key] + ' ';
+  }
+}
+
+execSync(command);

--- a/src/Client.js
+++ b/src/Client.js
@@ -19,9 +19,12 @@ export default class Client {
     d.on('remote', function(remote) {
       setInterval(() => {
         remote.status('', results => {
+          // TODO(allenk): make the results more robust, and invalidate full runs from the server
           if (results.length && !this.completedFullRun) {
             this.completedFullRun = true;
             prettyPrintResults(results);
+            d.end();
+            process.exit(0);
           } else {
             return;
           }

--- a/src/Client.js
+++ b/src/Client.js
@@ -11,6 +11,7 @@ function prettyPrintResults(results) {
 export default class Client {
   constructor(port) {
     this.port = port;
+    this.completedFullRun = false;
   }
 
   connect() {
@@ -18,8 +19,12 @@ export default class Client {
     d.on('remote', function(remote) {
       setInterval(() => {
         remote.status('', results => {
-          console.log(results);
-          prettyPrintResults(results);
+          if (results.length && !this.completedFullRun) {
+            this.completedFullRun = true;
+            prettyPrintResults(results);
+          } else {
+            return;
+          }
         });
       }, 1000);
     });

--- a/src/Client.js
+++ b/src/Client.js
@@ -1,18 +1,27 @@
 import dnode from 'dnode';
 const CLIEngine = require('eslint').CLIEngine;
 
-const ROOT_DIR = '/Users/arthur/code/pinboard/webapp';
-const eslint = new CLIEngine({ cwd: ROOT_DIR });
+const eslint = new CLIEngine();
 
 function prettyPrintResults(results) {
-  var formatter = eslint.getFormatter();
+  const formatter = eslint.getFormatter();
   console.log(formatter(results));
 }
 
-var d = dnode.connect(5004);
-d.on('remote', function(remote) {
-  remote.status('', results => {
-    prettyPrintResults(results);
-    d.end();
-  });
-});
+export default class Client {
+  constructor(port) {
+    this.port = port;
+  }
+
+  connect() {
+    const d = dnode.connect(this.port);
+    d.on('remote', function(remote) {
+      setInterval(() => {
+        remote.status('', results => {
+          console.log(results);
+          prettyPrintResults(results);
+        });
+      }, 1000);
+    });
+  }
+}

--- a/src/LintRunner.js
+++ b/src/LintRunner.js
@@ -17,7 +17,6 @@ function run(config, files) {
   // files.forEach(function(file) {
   //   workerToFile[hash(file)].push(file);
   // });
-
   return Promise.all(
     files.map((file, index) => {
       return workersPromise({

--- a/src/Server.js
+++ b/src/Server.js
@@ -25,7 +25,6 @@ const getResultsFromCache = () => {
 }
 
 const lintFile = (file) => {
-  process.send({file: file});
   if (eslint.isPathIgnored(path.join(ROOT_DIR, file))) {
     return;
   }
@@ -72,6 +71,7 @@ export default class Server {
   }
 
   _setupSaneWatcher() {
+    // TODO(allenk): Fix the glob to come from a top-level .esprintrc file
     const watcher = sane(process.cwd(), {
       glob: 'app/**/*.js',
       ignored: [/node_modules/],
@@ -85,7 +85,7 @@ export default class Server {
       });
     });
     watcher.on('change', (filepath, root, stat) => {
-      process.send({fileChanged: filepath});
+      //TODO(allenk): Check for .eslintrc changes, invalidate the cache, and lint all files again
       lintFile(filepath);
     });
     watcher.on('add', (filepath, root, stat) => {

--- a/src/Server.js
+++ b/src/Server.js
@@ -1,6 +1,5 @@
 import dnode from 'dnode';
 import path from 'path';
-import WatchmanClient from './WatchmanClient';
 import sane from 'sane';
 import glob from 'glob';
 import { run as runLint } from './LintRunner';
@@ -55,7 +54,6 @@ export default class Server {
     this.numWorkers = numWorkers;
     this.pathsToLint = pathsToLint;
 
-    // this._setupWatcher(WatchmanClient);
     this._setupSaneWatcher();
 
     const server = dnode({
@@ -73,18 +71,7 @@ export default class Server {
     server.listen(this.port);
   }
 
-  _setupWatcher(Client) {
-    const client = new Client();
-    client.watch({
-      dir: ROOT_DIR,
-      onChange: changedFile => {
-        lintFile(changedFile);
-      }
-    });
-  }
-
   _setupSaneWatcher() {
-    // const glob = getFullFileNames(this.pathsToLint);
     const watcher = sane(process.cwd(), {
       glob: 'app/**/*.js',
       ignored: [/node_modules/],
@@ -94,17 +81,15 @@ export default class Server {
 
     watcher.on('ready', () => {
       glob(watcher.globs[0], {}, (err, files) => {
-        if (files) {
-          lintAllFiles(files);
-        }
+        lineAllFiles(files);
       });
     });
     watcher.on('change', (filepath, root, stat) => {
       process.send({fileChanged: filepath});
-      lintFile(filePath);
+      lintFile(filepath);
     });
     watcher.on('add', (filepath, root, stat) => {
-      lintFile(filePath);
+      lintFile(filepath);
     });
   }
 }

--- a/src/Server.js
+++ b/src/Server.js
@@ -81,7 +81,7 @@ export default class Server {
 
     watcher.on('ready', () => {
       glob(watcher.globs[0], {}, (err, files) => {
-        lineAllFiles(files);
+        lintAllFiles(files);
       });
     });
     watcher.on('change', (filepath, root, stat) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,20 +1,70 @@
 #!/usr/bin/env node
 
 import yargs from 'yargs';
+import Client from './Client.js';
 import { fork } from 'child_process';
-import { isPortTaken } from './util';
+import { isPortTaken, promisify } from './util';
 
-isPortTaken(5004).then(isTaken => {
-  // start the server if it isn't running
-  if (!isTaken) {
-    fork(
-      require.resolve('./startServer.js'),
-      {
-        // silent: true
-      }
-    );
-  }
+const DEFAULT_PORT_NUMBER = 5004;
+// TODO(allenk): See if this does anything
+const DEFAULT_NUM_WORKERS = 4;
 
-  // wait for the server to be ready
-  require('./Client.js');
-});
+// TODO(allenk): This is less than ideal right now since we take in args from the main process
+// Just to pass them back through the server and client
+
+const start = () => {
+  const usage = `Spins up a server on a specified port to run eslint in parallel.
+    Usage: esprint [args]`;
+
+  let options = yargs
+    .usage(usage)
+    .describe('port', 'The port for the server and client to connect to.')
+    .option('port', {
+      alias: 'p',
+      default: DEFAULT_PORT_NUMBER,
+    })
+    .describe('workers', 'The number of parallel workers to run')
+    .option('workers', {
+      alias: 'w',
+      default: DEFAULT_NUM_WORKERS
+    })
+    .help().argv
+
+  const pathsToWatch = options._;
+
+  Object.assign(options, {paths: pathsToWatch});
+
+  connect(options);
+};
+
+const connect = (options) => {
+  const {
+    port,
+    paths,
+    workers,
+  } = options;
+
+  isPortTaken(port).then(isTaken => {
+    // start the server if it isn't running
+    const client = new Client(port);
+    if (!isTaken) {
+      const child = fork(
+        require.resolve('./startServer.js'), [port, workers, paths], {/* silent: true */}
+      );
+
+      child.on('message', message => {
+        console.log(message);
+        if (message) {
+          // Wait for the server to start before connecting
+          client.connect();
+        }
+      });
+    } else {
+      // Connect anyways
+      // TODO(allenk): Actually check that the server is occupying the port
+      client.connect();
+    }
+  });
+};
+
+start();

--- a/src/cli.js
+++ b/src/cli.js
@@ -54,7 +54,7 @@ const connect = (options) => {
 
       child.on('message', message => {
         console.log(message);
-        if (message) {
+        if (message.server) {
           // Wait for the server to start before connecting
           client.connect();
         }

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,9 +9,6 @@ const DEFAULT_PORT_NUMBER = 5004;
 // TODO(allenk): See if this does anything
 const DEFAULT_NUM_WORKERS = 4;
 
-// TODO(allenk): This is less than ideal right now since we take in args from the main process
-// Just to pass them back through the server and client
-
 const start = () => {
   const usage = `Spins up a server on a specified port to run eslint in parallel.
     Usage: esprint [args]`;

--- a/src/startServer.js
+++ b/src/startServer.js
@@ -7,4 +7,6 @@ if (args.length === 2) {
   args.push(process.cwd());
 }
 
+process.send({serverArgs: args});
+
 const server = new Server(args[0], args[1], args[2]);

--- a/src/startServer.js
+++ b/src/startServer.js
@@ -1,2 +1,10 @@
 import Server from './server';
-const server = new Server();
+
+let args = process.argv.slice(2);
+
+// If no paths/files to lint were specified, just take the CWD
+if (args.length === 2) {
+  args.push(process.cwd());
+}
+
+const server = new Server(args[0], args[1], args[2]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,6 +624,12 @@ browserslist@^1.4.0:
     caniuse-db "^1.0.30000631"
     electron-to-chromium "^1.2.5"
 
+bser@1.0.2:
+  version "1.0.2"
+  resolved "http://sinopia.pinadmin.com:8080/bser/-/bser-1.0.2.tgz#381116970b2a6deea5646dd15dd7278444b56169"
+  dependencies:
+    node-int64 "^0.4.0"
+
 bser@^2.0.0:
   version "2.0.0"
   resolved "http://sinopia.pinadmin.com:8080/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -815,6 +821,12 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "http://sinopia.pinadmin.com:8080/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+exec-sh@^0.2.0:
+  version "0.2.0"
+  resolved "http://sinopia.pinadmin.com:8080/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
+  dependencies:
+    merge "^1.1.3"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "http://sinopia.pinadmin.com:8080/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -840,6 +852,12 @@ extglob@^0.3.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "http://sinopia.pinadmin.com:8080/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fb-watchman@^1.8.0:
+  version "1.9.2"
+  resolved "http://sinopia.pinadmin.com:8080/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"
+  dependencies:
+    bser "1.0.2"
 
 fb-watchman@^2.0.0:
   version "2.0.0"
@@ -1236,6 +1254,16 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
+makeerror@1.0.x:
+  version "1.0.11"
+  resolved "http://sinopia.pinadmin.com:8080/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
+  dependencies:
+    tmpl "1.0.x"
+
+merge@^1.1.3:
+  version "1.2.0"
+  resolved "http://sinopia.pinadmin.com:8080/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+
 micromatch@^2.1.5:
   version "2.3.11"
   resolved "http://sinopia.pinadmin.com:8080/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -1274,7 +1302,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "http://sinopia.pinadmin.com:8080/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "http://sinopia.pinadmin.com:8080/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1634,6 +1662,18 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "http://sinopia.pinadmin.com:8080/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+sane@^1.6.0:
+  version "1.6.0"
+  resolved "http://sinopia.pinadmin.com:8080/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
+  dependencies:
+    anymatch "^1.3.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^1.8.0"
+    minimatch "^3.0.2"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.10.0"
+
 "semver@2 || 3 || 4 || 5", semver@~5.3.0:
   version "5.3.0"
   resolved "http://sinopia.pinadmin.com:8080/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -1756,6 +1796,10 @@ tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tmpl@1.0.x:
+  version "1.0.4"
+  resolved "http://sinopia.pinadmin.com:8080/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
+
 to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "http://sinopia.pinadmin.com:8080/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
@@ -1818,6 +1862,16 @@ verror@1.3.6:
   resolved "http://sinopia.pinadmin.com:8080/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+walker@~1.0.5:
+  version "1.0.7"
+  resolved "http://sinopia.pinadmin.com:8080/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
+  dependencies:
+    makeerror "1.0.x"
+
+watch@~0.10.0:
+  version "0.10.0"
+  resolved "http://sinopia.pinadmin.com:8080/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
 
 weak@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR introduces a bunch of refactoring towards getting the ESLint server production-ready. 

Namely, it: 
- Introduces command-line arguments. 
- Eliminates race condition for connection between client and server.
- Simplifies watching logic to use `sane`.
- Adds an eslint dependency-installation script to simplify development for esprint

There's still some things to do, as noted in TODOs throughout the code, which will be addressed in future PRs. 