### PR TITLE
Show a message when globbing for files

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -1,6 +1,5 @@
 import dnode from 'dnode';
-
-const CLIEngine = require('eslint').CLIEngine;
+import { CLIEngine } from 'eslint';
 
 const eslint = new CLIEngine();
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -4,7 +4,7 @@ import sane from 'sane';
 import glob from 'glob';
 import fs from 'fs';
 import { run as runLint } from './LintRunner';
-const CLIEngine = require('eslint').CLIEngine;
+import { CLIEngine } from 'eslint';
 
 const ROOT_DIR = process.cwd();
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -54,6 +54,7 @@ export default class Server {
     });
 
     watcher.on('ready', () => {
+      process.send({gathering: "Gathering files..."})
       let filePaths = [];
       for (let i = 0; i < paths.length; i++) {
         const files = glob.sync(paths[i], {});

--- a/src/cli.js
+++ b/src/cli.js
@@ -59,6 +59,8 @@ const connect = (options) => {
         if (message.server) {
           // Wait for the server to start before connecting
           client.connect();
+        } else if (message.gathering) {
+          process.stdout.write(message.gathering);
         }
       });
     } else {


### PR DESCRIPTION
Previously, the console was left blank as the server globbed for files. Since that process could potentially take some time, we should show a simple message. This is pretty bad right now, since we log from two different places (IPC and the dnode connection), but it works