### PR TITLE
Add command to kill background server

### DIFF
--- a/scripts/killPort.sh
+++ b/scripts/killPort.sh
@@ -1,0 +1,2 @@
+lsof -i TCP:5004 | grep LISTEN | awk '{print $2}' | xargs kill -9
+echo "Process found on port 5004 and killed"

--- a/scripts/killPort.sh
+++ b/scripts/killPort.sh
@@ -1,2 +1,0 @@
-lsof -i TCP:5004 | grep LISTEN | awk '{print $2}' | xargs kill -9
-echo "Process found on port 5004 and killed"

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@
 import yargs from 'yargs';
 import Client from './Client.js';
 import fs from 'fs';
+import { killPort } from './commands/kill.js';
 import { fork } from 'child_process';
 import { isPortTaken, findFile } from './util';
 
@@ -27,16 +28,25 @@ const start = () => {
     })
     .help().argv
 
-  const filePath = findFile('.esprintrc');
+  const commands = yargs.argv._;
 
-  if (!filePath) {
-    console.error('Unable to find `.esprintrc` file. Exiting...');
-    process.exit(0);
+  // Normal esprint run
+  if (!commands.length) {
+    const filePath = findFile('.esprintrc');
+
+    if (!filePath) {
+      console.error('Unable to find `.esprintrc` file. Exiting...');
+      process.exit(0);
+    } else {
+       Object.assign(options, {rcPath: filePath});
+    }
+    connect(options);
   } else {
-     Object.assign(options, {rcPath: filePath});
+    if (commands[0] === 'kill') {
+      killPort();
+      process.exit(0)
+    }
   }
-
-  connect(options);
 };
 
 const connect = (options) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,39 +14,34 @@ const start = () => {
   const usage = `Spins up a server on a specified port to run eslint in parallel.
     Usage: esprint [args]`;
 
-  let options = yargs
+  const argv = yargs
     .usage(usage)
     .describe('port', 'The port for the server and client to connect to.')
-    .option('port', {
-      alias: 'p',
-      default: DEFAULT_PORT_NUMBER,
-    })
     .describe('workers', 'The number of parallel workers to run')
-    .option('workers', {
-      alias: 'w',
-      default: DEFAULT_NUM_WORKERS
-    })
-    .help().argv
-
-  const commands = yargs.argv._;
-
-  // Normal esprint run
-  if (!commands.length) {
-    const filePath = findFile('.esprintrc');
-
-    if (!filePath) {
-      console.error('Unable to find `.esprintrc` file. Exiting...');
-      process.exit(0);
-    } else {
-       Object.assign(options, {rcPath: filePath});
-    }
-    connect(options);
-  } else {
-    if (commands[0] === 'kill') {
+    .command('kill', 'Kills the background server', () => {}, () => {
       killPort();
-      process.exit(0)
-    }
-  }
+    })
+    .command(['run', '*'], 'The default command to run esprint', {
+      port: {
+        alias: 'p',
+        default: DEFAULT_PORT_NUMBER,
+      },
+      workers: {
+        alias: 'w',
+        default: DEFAULT_NUM_WORKERS
+      }
+    }, (argv) => {
+      const filePath = findFile('.esprintrc');
+
+      if (!filePath) {
+        console.error('Unable to find `.esprintrc` file. Exiting...');
+        process.exit(0);
+      } else {
+         Object.assign(argv, {rcPath: filePath});
+      }
+      connect(argv);
+    })
+    .help().argv;
 };
 
 const connect = (options) => {

--- a/src/commands/kill.js
+++ b/src/commands/kill.js
@@ -1,0 +1,8 @@
+import path from 'path';
+import { execSync } from 'child_process';
+
+export const killPort = () => {
+  const pathToScript = path.resolve('node_modules', 'esprint', 'scripts/killPort.sh');
+  const command = `sh ${pathToScript}`;
+  execSync(command);
+}

--- a/src/commands/kill.js
+++ b/src/commands/kill.js
@@ -1,7 +1,6 @@
 import path from 'path';
 import { execSync } from 'child_process';
 
-
 export const killPort = () => {
   const command = `lsof -i TCP:5004 | grep LISTEN | awk '{print $2}' | xargs kill -9`;
   execSync(command);

--- a/src/commands/kill.js
+++ b/src/commands/kill.js
@@ -1,8 +1,9 @@
 import path from 'path';
 import { execSync } from 'child_process';
 
+
 export const killPort = () => {
-  const pathToScript = path.resolve('node_modules', 'esprint', 'scripts/killPort.sh');
-  const command = `sh ${pathToScript}`;
+  const command = `lsof -i TCP:5004 | grep LISTEN | awk '{print $2}' | xargs kill -9`;
   execSync(command);
+  console.log("Server running on port 5004 found and killed");
 }


### PR DESCRIPTION
This implements effectively the `esprint kill` command, which stops the background server from running entirely. It's not perfect right now, since the port is hard-coded as 5004. I want to iterate on the way we store the port in the future, but wanted to get this in as a starting point for now. 