### PR TITLE
Add `esprint run` command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@
 import yargs from 'yargs';
 import Client from './Client.js';
 import fs from 'fs';
-import { killPort } from './commands/kill.js';
+import { killPort, run } from './commands/';
 import { fork } from 'child_process';
 import { isPortTaken, findFile } from './util';
 
@@ -21,7 +21,7 @@ const start = () => {
     .command('kill', 'Kills the background server', () => {}, () => {
       killPort();
     })
-    .command(['run', '*'], 'The default command to run esprint', {
+    .command(['start', '*'], 'Starts up a background server which listens for file changes', {
       port: {
         alias: 'p',
         default: DEFAULT_PORT_NUMBER,
@@ -40,6 +40,22 @@ const start = () => {
          Object.assign(argv, {rcPath: filePath});
       }
       connect(argv);
+    })
+    .command('run', 'Runs parallelized esprint', {
+      workers: {
+        alias: 'w',
+        default: DEFAULT_NUM_WORKERS
+      }
+    }, (argv) => {
+      const filePath = findFile('.esprintrc');
+
+      if (!filePath) {
+        console.error('Unable to find `.esprintrc` file. Exiting...');
+        process.exit(0);
+      } else {
+         Object.assign(argv, {rcPath: filePath});
+      }
+      run(argv);
     })
     .help().argv;
 };

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,0 +1,7 @@
+import { killPort } from './kill.js';
+import { runParallelLint } from './run.js';
+
+export {
+  killPort,
+  runParallelLint as run
+};

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,0 +1,64 @@
+import LintRunner from '../LintRunner';
+import glob from 'glob';
+import path from 'path';
+import fs from 'fs';
+import { CLIEngine } from 'eslint';
+
+const ROOT_DIR = process.cwd();
+const eslint = new CLIEngine({ cwd: ROOT_DIR });
+
+const processEsprintrc = (rcPath) => {
+  const rc = JSON.parse(fs.readFileSync(rcPath));
+  return [rc.paths, rc.ignored];
+}
+
+export const runParallelLint = (options) => {
+  const {
+    workers,
+    rcPath,
+  } = options;
+
+  const lintRunner = new LintRunner(workers);
+  const [paths, ignored] = processEsprintrc(rcPath);
+
+  let filePaths = [];
+  process.stdout.write("Collecting files...[this may take a little bit]");
+  for (let i = 0; i < paths.length; i++) {
+    const files = glob.sync(paths[i], {});
+    files.forEach((file, idx) => {
+      filePaths.push(file);
+    })
+  }
+
+  let filesToProcess = 0;
+  let lintResults = [];
+
+  filePaths.map((file, _) => {
+    if (eslint.isPathIgnored(path.join(ROOT_DIR, file)) || file.indexOf('eslint') !== -1) {
+      return;
+    }
+    filesToProcess++;
+    lintRunner.run({ cwd: ROOT_DIR }, [file])
+      .then((results) => {
+        const result = results[0];
+        lintResults.push(result);
+        filesToProcess--;
+      });
+  });
+
+  const interval = setInterval(() => {
+    process.stdout.clearLine();
+    process.stdout.cursorTo(0);
+    process.stdout.write(`Linting files...${filesToProcess} left to lint`);
+
+    if (filesToProcess === 0) {
+      clearInterval(interval);
+      lintResults = lintResults.filter((result) => {
+        return result.warningCount > 0 || result.errorCount > 0;
+      });
+      const formatter = eslint.getFormatter();
+      console.log(formatter(lintResults));
+      process.exit(0);
+    }
+  }, 1000);
+};


### PR DESCRIPTION
This PR adds an `esprint run` command, which just runs parallelized eslint without standing up a background server that watches for changes. 