### PR TITLE
Better documentation and simplified API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,14 @@ esprint speeds up eslint by running the linting engine across multiple threads, 
 
 ## Usage
 
-To run the esprint server, run the following command:
-
-```
-$ esprint start --workers=[num_workers] --port=[port_number]
-```
-
-The `--workers` argument specifies how many worker threads you want to start linting your application (defaults to 4), while the `--port` argument
-specifies which port to start the background server on (defaults to 5004).
-
-If you want to kill the background server, run:
-
-```
-$ esprint kill
-```
-
-Otherwise, you can tell esprint to lint all files without spinning up a server:
-
-```
-$ esprint run --workers=[num_workers]
-```
-
-### `.esprintrc`
 In order to use esprint, first place an `.esprintrc` file in your project. This is similar to a `.flowconfig`. The `.esprintrc` file describes
-which paths to lint and which paths to ignore. The two required keys are `paths`, and `ignored`, which both take arrays of globs. A sample `.esprintrc` file is shown as follows:
+which paths to lint, which paths to ignore, as well as (optionally) what port to start a lint server on, and how many threads to use when linting.
+A sample `.esprintrc` file is shown as follows:
 
 ```js
 {
+  "port": 5004 ,
+  "workers": 4,
   "paths": [
       "foo/*.js",
       "bar/**/*.js",
@@ -41,6 +22,22 @@ which paths to lint and which paths to ignore. The two required keys are `paths`
     ]
 }
 ```
+
+To run the esprint server, run the following command:
+
+```
+$ esprint
+```
+
+If the `port` key is not specified in the `.eslintrc` file, then esprint will run parallelized eslint without standing up a background server.
+
+If the server is running in the background, you can use the following command to stop the background server:
+
+```
+$ esprint kill
+```
+
+You can run `esprint` from any subdirectory that `.esprintrc` is located in, and it will still properly lint all files as specified.
 
 
 ## Developing for ESprint

--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
 # esprint [![npm version](https://img.shields.io/npm/v/esprint.svg?style=flat)](https://www.npmjs.com/package/esprint)
 
-esprint speeds up eslint by running the linting engine across multiple threads, and setting up a server daemon to cache the lint status of each file in memory. It uses a watcher to determine when files change, as to only re-lint what is necessary.
+esprint speeds up eslint by running the linting engine across multiple threads, and optionally sets up a server daemon to cache the lint status of each file in memory. It uses a watcher to determine when files change, as to only re-lint what is necessary.
 
 ## Usage
-TODO
+
+To run the esprint server, run the following command:
+
+```
+$ esprint start --workers=[num_workers] --port=[port_number]
+```
+
+The `--workers` argument specifies how many worker threads you want to start linting your application (defaults to 4), while the `--port` argument
+specifies which port to start the background server on (defaults to 5004).
+
+If you want to kill the background server, run:
+
+```
+$ esprint kill
+```
+
+Otherwise, you can tell esprint to lint all files without spinning up a server:
+
+```
+$ esprint run --workers=[num_workers]
+```
+
+### `.esprintrc`
+In order to use esprint, first place an `.esprintrc` file in your project. This is similar to a `.flowconfig`. The `.esprintrc` file describes
+which paths to lint and which paths to ignore. The two required keys are `paths`, and `ignored`, which both take arrays of globs. A sample `.esprintrc` file is shown as follows:
+
+```js
+{
+  "paths": [
+      "foo/*.js",
+      "bar/**/*.js",
+    ],
+
+  "ignored": [
+      "**/node_modules/**/*"
+    ]
+}
+```
+
 
 ## Developing for ESprint
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "glob": "^7.1.1",
     "sane": "^1.6.0",
     "worker-farm": "^1.3.1",
-    "yargs": "^6.5.0"
+    "yargs": "^8.0.1"
   },
   "peerDependencies": {
     "eslint": "^3"

--- a/src/Server.js
+++ b/src/Server.js
@@ -15,6 +15,8 @@ export default class Server {
     const {
       workers,
       port,
+      paths,
+      ignored,
       rcPath,
     } = options;
 
@@ -27,8 +29,7 @@ export default class Server {
 
     const rootDir = path.dirname(this.rcPath);
 
-    this._setupEsprintrc(this.rcPath);
-    this._setupWatcher(rootDir, this.paths, this.ignored);
+    this._setupWatcher(rootDir, paths.split(","), ignored.split(","));
 
     const server = dnode({
       status: (param, cb) => {
@@ -84,13 +85,6 @@ export default class Server {
     watcher.on('add', (filepath, root, stat) => {
       this.lintFile(filepath);
     });
-  }
-
-  _setupEsprintrc() {
-    process.send({message: "Processing .esprintrc"});
-    const rc = JSON.parse(fs.readFileSync(this.rcPath));
-    this.paths = rc.paths;
-    this.ignored = rc.ignored;
   }
 
   getResultsFromCache() {

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,61 +11,46 @@ const DEFAULT_PORT_NUMBER = 5004;
 const DEFAULT_NUM_WORKERS = 4;
 
 const start = () => {
+  const options = {};
   const usage = `Spins up a server on a specified port to run eslint in parallel.
     Usage: esprint [args]`;
 
   const argv = yargs
     .usage(usage)
-    .describe('port', 'The port for the server and client to connect to.')
-    .describe('workers', 'The number of parallel workers to run')
     .command('kill', 'Kills the background server', () => {}, () => {
       killPort();
     })
-    .command(['*', 'start'], 'Starts up a background server which listens for file changes', {
-      port: {
-        alias: 'p',
-        default: DEFAULT_PORT_NUMBER,
-      },
-      workers: {
-        alias: 'w',
-        default: DEFAULT_NUM_WORKERS
-      }
-    }, (argv) => {
+    .command(['*', 'start'], 'Starts up a background server which listens for file changes. If no port is specified, then runs parallelized eslint with no background server', () => {}, (argv) => {
       const filePath = findFile('.esprintrc');
 
       if (!filePath) {
         console.error('Unable to find `.esprintrc` file. Exiting...');
         process.exit(0);
       } else {
-         Object.assign(argv, {rcPath: filePath});
-      }
-      connect(argv);
-    })
-    .command('run', 'Runs parallelized esprint', {
-      workers: {
-        alias: 'w',
-        default: DEFAULT_NUM_WORKERS
-      }
-    }, (argv) => {
-      const filePath = findFile('.esprintrc');
+        const rc = JSON.parse(fs.readFileSync(filePath));
+        Object.assign(options, rc);
+        Object.assign(options, {rcPath: filePath});
 
-      if (!filePath) {
-        console.error('Unable to find `.esprintrc` file. Exiting...');
-        process.exit(0);
-      } else {
-         Object.assign(argv, {rcPath: filePath});
+        if (!rc.workers) {
+         Object.assign(options, {workers: DEFAULT_NUM_WORKERS});
+        }
+        if (!rc.port) {
+          run(options);
+        } else {
+          connect(options);
+        }
       }
-      run(argv);
     })
     .help().argv;
 };
 
 const connect = (options) => {
-  const {
-    port,
-    workers,
-    rcPath,
-  } = options;
+  const args = [];
+  for (const key in options) {
+    args.push(`--${key}=${options[key]}`);
+  }
+
+  const port = options.port;
 
   isPortTaken(port).then(isTaken => {
     // start the server if it isn't running
@@ -73,7 +58,7 @@ const connect = (options) => {
 
     if (!isTaken) {
       const child = fork(
-        require.resolve('./startServer.js'), [`--port=${port}`, `--workers=${workers}`, `--rcPath=${rcPath}`], {/* silent: true */}
+        require.resolve('./startServer.js'), args, {/* silent: true */}
       );
 
       child.on('message', message => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -21,7 +21,7 @@ const start = () => {
     .command('kill', 'Kills the background server', () => {}, () => {
       killPort();
     })
-    .command(['start', '*'], 'Starts up a background server which listens for file changes', {
+    .command(['*', 'start'], 'Starts up a background server which listens for file changes', {
       port: {
         alias: 'p',
         default: DEFAULT_PORT_NUMBER,

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -7,19 +7,14 @@ import { CLIEngine } from 'eslint';
 const ROOT_DIR = process.cwd();
 const eslint = new CLIEngine({ cwd: ROOT_DIR });
 
-const processEsprintrc = (rcPath) => {
-  const rc = JSON.parse(fs.readFileSync(rcPath));
-  return [rc.paths, rc.ignored];
-}
-
 export const runParallelLint = (options) => {
   const {
     workers,
-    rcPath,
+    paths,
+    ignored
   } = options;
 
   const lintRunner = new LintRunner(workers);
-  const [paths, ignored] = processEsprintrc(rcPath);
 
   let filePaths = [];
   process.stdout.write("Collecting files...[this may take a little bit]");

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,9 +644,9 @@ builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "http://sinopia.pinadmin.com:8080/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
-camelcase@^3.0.0:
-  version "3.0.0"
-  resolved "http://sinopia.pinadmin.com:8080/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "http://sinopia.pinadmin.com:8080/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-db@^1.0.30000631:
   version "1.0.30000636"
@@ -728,6 +728,13 @@ core-js@^2.4.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "http://sinopia.pinadmin.com:8080/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cross-spawn@^4.0.0:
+  version "4.0.2"
+  resolved "http://sinopia.pinadmin.com:8080/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -827,6 +834,18 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
+execa@^0.5.0:
+  version "0.5.1"
+  resolved "http://sinopia.pinadmin.com:8080/execa/-/execa-0.5.1.tgz#de3fb85cb8d6e91c85bcbceb164581785cb57b36"
+  dependencies:
+    cross-spawn "^4.0.0"
+    get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "http://sinopia.pinadmin.com:8080/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -879,12 +898,11 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-find-up@^1.0.0:
-  version "1.1.2"
-  resolved "http://sinopia.pinadmin.com:8080/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+find-up@^2.0.0:
+  version "2.1.0"
+  resolved "http://sinopia.pinadmin.com:8080/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
-    path-exists "^2.0.0"
-    pinkie-promise "^2.0.0"
+    locate-path "^2.0.0"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -956,6 +974,13 @@ gauge@~2.7.1:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "http://sinopia.pinadmin.com:8080/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stream@^2.2.0:
+  version "2.3.1"
+  resolved "http://sinopia.pinadmin.com:8080/get-stream/-/get-stream-2.3.1.tgz#5f38f93f346009666ee0150a054167f91bdd95de"
+  dependencies:
+    object-assign "^4.0.1"
+    pinkie-promise "^2.0.0"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -1127,6 +1152,10 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "http://sinopia.pinadmin.com:8080/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -1147,17 +1176,21 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "http://sinopia.pinadmin.com:8080/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "http://sinopia.pinadmin.com:8080/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "http://sinopia.pinadmin.com:8080/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
-is-utf8@^0.2.0:
-  version "0.2.1"
-  resolved "http://sinopia.pinadmin.com:8080/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
-
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "http://sinopia.pinadmin.com:8080/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -1234,15 +1267,21 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-load-json-file@^1.0.0:
-  version "1.1.0"
-  resolved "http://sinopia.pinadmin.com:8080/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
   dependencies:
     graceful-fs "^4.1.2"
     parse-json "^2.2.0"
     pify "^2.0.0"
-    pinkie-promise "^2.0.0"
-    strip-bom "^2.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 lodash@^4.2.0:
   version "4.17.4"
@@ -1254,11 +1293,24 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
+lru-cache@^4.0.1:
+  version "4.0.2"
+  resolved "http://sinopia.pinadmin.com:8080/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  dependencies:
+    pseudomap "^1.0.1"
+    yallist "^2.0.0"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "http://sinopia.pinadmin.com:8080/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+mem@^1.1.0:
+  version "1.1.0"
+  resolved "http://sinopia.pinadmin.com:8080/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -1291,6 +1343,10 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   resolved "http://sinopia.pinadmin.com:8080/mime-types/-/mime-types-2.1.14.tgz#f7ef7d97583fcaf3b7d282b6f8b5679dab1e94ee"
   dependencies:
     mime-db "~1.26.0"
+
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "http://sinopia.pinadmin.com:8080/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
 
 minimatch@^3.0.0, minimatch@^3.0.2:
   version "3.0.3"
@@ -1361,6 +1417,12 @@ normalize-path@^2.0.1:
   version "2.0.1"
   resolved "http://sinopia.pinadmin.com:8080/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
 
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "http://sinopia.pinadmin.com:8080/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
 npmlog@^4.0.1:
   version "4.0.2"
   resolved "http://sinopia.pinadmin.com:8080/npmlog/-/npmlog-4.0.2.tgz#d03950e0e78ce1527ba26d2a7592e9348ac3e75f"
@@ -1378,7 +1440,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "http://sinopia.pinadmin.com:8080/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "http://sinopia.pinadmin.com:8080/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1405,11 +1467,13 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "http://sinopia.pinadmin.com:8080/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-locale@^1.4.0:
-  version "1.4.0"
-  resolved "http://sinopia.pinadmin.com:8080/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+os-locale@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/os-locale/-/os-locale-2.0.0.tgz#15918ded510522b81ee7ae5a309d54f639fc39a4"
   dependencies:
+    execa "^0.5.0"
     lcid "^1.0.0"
+    mem "^1.1.0"
 
 os-tmpdir@^1.0.1:
   version "1.0.2"
@@ -1422,6 +1486,20 @@ output-file-sync@^1.1.0:
     graceful-fs "^4.1.4"
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-limit@^1.1.0:
+  version "1.1.0"
+  resolved "http://sinopia.pinadmin.com:8080/p-limit/-/p-limit-1.1.0.tgz#b07ff2d9a5d88bec806035895a2bab66a27988bc"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  dependencies:
+    p-limit "^1.1.0"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -1438,23 +1516,23 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-path-exists@^2.0.0:
-  version "2.1.0"
-  resolved "http://sinopia.pinadmin.com:8080/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
-  dependencies:
-    pinkie-promise "^2.0.0"
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "http://sinopia.pinadmin.com:8080/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-type@^1.0.0:
-  version "1.1.0"
-  resolved "http://sinopia.pinadmin.com:8080/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "http://sinopia.pinadmin.com:8080/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
-    graceful-fs "^4.1.2"
     pify "^2.0.0"
-    pinkie-promise "^2.0.0"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -1490,6 +1568,10 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "http://sinopia.pinadmin.com:8080/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
+pseudomap@^1.0.1:
+  version "1.0.2"
+  resolved "http://sinopia.pinadmin.com:8080/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "http://sinopia.pinadmin.com:8080/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -1514,20 +1596,20 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-read-pkg-up@^1.0.1:
-  version "1.0.1"
-  resolved "http://sinopia.pinadmin.com:8080/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
   dependencies:
-    find-up "^1.0.0"
-    read-pkg "^1.0.0"
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
 
-read-pkg@^1.0.0:
-  version "1.1.0"
-  resolved "http://sinopia.pinadmin.com:8080/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
   dependencies:
-    load-json-file "^1.0.0"
+    load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
-    path-type "^1.0.0"
+    path-type "^2.0.0"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2:
   version "2.2.6"
@@ -1739,12 +1821,19 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "http://sinopia.pinadmin.com:8080/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
 string_decoder@~0.10.x:
@@ -1761,11 +1850,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-bom@^2.0.0:
-  version "2.0.0"
-  resolved "http://sinopia.pinadmin.com:8080/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
-  dependencies:
-    is-utf8 "^0.2.0"
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -1880,9 +1971,15 @@ weak@^1.0.0:
     bindings "^1.2.1"
     nan "^2.0.5"
 
-which-module@^1.0.0:
-  version "1.0.0"
-  resolved "http://sinopia.pinadmin.com:8080/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+
+which@^1.2.9:
+  version "1.2.14"
+  resolved "http://sinopia.pinadmin.com:8080/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
 
 wide-align@^1.1.0:
   version "1.1.0"
@@ -1916,26 +2013,30 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "http://sinopia.pinadmin.com:8080/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yargs-parser@^4.2.0:
-  version "4.2.1"
-  resolved "http://sinopia.pinadmin.com:8080/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
-  dependencies:
-    camelcase "^3.0.0"
+yallist@^2.0.0:
+  version "2.1.2"
+  resolved "http://sinopia.pinadmin.com:8080/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs@^6.5.0:
-  version "6.6.0"
-  resolved "http://sinopia.pinadmin.com:8080/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
+yargs-parser@^7.0.0:
+  version "7.0.0"
+  resolved "http://sinopia.pinadmin.com:8080/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
-    camelcase "^3.0.0"
+    camelcase "^4.1.0"
+
+yargs@^8.0.1:
+  version "8.0.1"
+  resolved "http://sinopia.pinadmin.com:8080/yargs/-/yargs-8.0.1.tgz#420ef75e840c1457a80adcca9bc6fa3849de51aa"
+  dependencies:
+    camelcase "^4.1.0"
     cliui "^3.2.0"
     decamelize "^1.1.1"
     get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^4.2.0"
+    yargs-parser "^7.0.0"


### PR DESCRIPTION
Addresses #14. Describes how to use esprint, including `.esprintrc` files, as well as the available commands.

In addition, it pulls out the command line args and moves them to the `.esprintrc` file (as described in the documentation)