### PR TITLE
Update install script to handle file-linked eslint dependencies

### DIFF
--- a/scripts/installDependencies.js
+++ b/scripts/installDependencies.js
@@ -4,21 +4,29 @@ const execSync = require('child_process').execSync;
 const readFileSync = require('fs').readFileSync;
 const path = require('path');
 
-const packageJson = JSON.parse(readFileSync(path.join(process.argv[2], 'package.json')));
+const dirPath = process.argv[2];
+const packageJson = JSON.parse(readFileSync(path.join(dirPath, 'package.json')));
 
 if (!packageJson) {
   console.log('No package.json found at the path specified. Exiting...');
   process.exit(0);
 }
 
-let command = 'npm i ';
+const install = 'npm i ';
+const link = 'npm ln '
+let dependencies = '';
 
 const devDeps = packageJson['devDependencies'];
 
 for (const key in devDeps) {
   if (key.indexOf('eslint') !== -1) {
-    command += `${key}@` + devDeps[key] + ' ';
+    // Manually link file: dependencies
+    if (devDeps[key].startsWith('file:')) {
+      execSync(`${link} ${path.join(dirPath, devDeps[key])}`);
+    } else {
+      dependencies += `${key}@${devDeps[key]} `;
+    }
   }
 }
 
-execSync(command);
+execSync(`${install} ${dependencies}`);


### PR DESCRIPTION
As title. The dependency-install script would throw errors when running into `file:`-linked dependencies in the specified `package.json`. This patch runs `npm link` for those packages, so that we get the dependencies into esprint's `node_modules`