### PR TITLE
Throw error when user specifies more worker threads than available cpus

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -28,12 +28,17 @@ const start = () => {
         process.exit(0);
       } else {
         const rc = JSON.parse(fs.readFileSync(filePath));
+
+        if (!rc.workers) {
+          Object.assign(options, {workers: DEFAULT_NUM_WORKERS});
+        } else if (rc.workers && rc.workers > require('os').cpus().length) {
+          conosle.error(`Cannot use the amount of worker threads specified! Maximum: ${require('os').cpus().length}. Specified: ${rc.workers}. Exiting...`);
+          process.exit(0);
+        }
+
         Object.assign(options, rc);
         Object.assign(options, {rcPath: filePath});
 
-        if (!rc.workers) {
-         Object.assign(options, {workers: DEFAULT_NUM_WORKERS});
-        }
         if (!rc.port) {
           run(options);
         } else {


### PR DESCRIPTION
As title. Since `worker-farm` defaults to `require('os').cpus().length`, we should throw an error if a user specifies more than that many threads in the `.esprintrc` file.