### PR TITLE
Make log messages consistent between server and non-server esprint runs

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -25,7 +25,7 @@ export default class Client {
             process.exit(results && results.length > 0 ? 1 : 0);
           } else {
             clearLine();
-            process.stdout.write(results.message + " " + results.files + " left to lint");
+            process.stdout.write(results.message);
           }
         });
       }, 1000);

--- a/src/Server.js
+++ b/src/Server.js
@@ -36,7 +36,7 @@ export default class Server {
         if (this.filesToProcess === 0) {
           return cb(this.getResultsFromCache());
         } else {
-          return cb({message: "Linting...", files: this.filesToProcess})
+          return cb({message: `Linting...${this.filesToProcess} left to lint`})
         }
       }
     });
@@ -55,7 +55,7 @@ export default class Server {
     });
 
     watcher.on('ready', () => {
-      process.send({message: "Reading files to be linted"});
+      process.send({message: "Reading files to be linted...[this may take a little bit]"});
       let filePaths = [];
       for (let i = 0; i < paths.length; i++) {
         const files = glob.sync(paths[i], {});

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -17,7 +17,7 @@ export const runParallelLint = (options) => {
   const lintRunner = new LintRunner(workers);
 
   let filePaths = [];
-  process.stdout.write("Collecting files...[this may take a little bit]");
+  process.stdout.write("Reading files to be linted...[this may take a little bit]");
   for (let i = 0; i < paths.length; i++) {
     const files = glob.sync(paths[i], {});
     files.forEach((file, idx) => {


### PR DESCRIPTION
Before, we were logging slightly different messages whenever we ran server and non-server runs. This PR cleans those up and makes them consistent across both.